### PR TITLE
Add async iterators support

### DIFF
--- a/include/hermes/AST/AsyncGenerator.h
+++ b/include/hermes/AST/AsyncGenerator.h
@@ -1,0 +1,14 @@
+#ifndef HERMES_AST_ASYNCGENERATORS_H
+#define HERMES_AST_ASYNCGENERATORS_H
+
+#include "hermes/AST/ESTree.h"
+
+namespace hermes {
+
+/// Recursively transforms the ESTree Node tree such that async generators
+/// are converted into generators
+void transformAsyncGenerators(Context &context, ESTree::Node *node);
+
+} // namespace hermes
+
+#endif

--- a/include/hermes/AST/TransformationsBase.h
+++ b/include/hermes/AST/TransformationsBase.h
@@ -1,0 +1,144 @@
+#include "hermes/AST/RecursiveVisitor.h"
+#include "hermes/Parser/JSLexer.h"
+#include "llvh/ADT/StringRef.h"
+
+namespace {
+using namespace hermes;
+
+/// Mutable vector that helps dealing with arrays of nodes safely.
+/// Once done with the vector, it can create an ESTree::NodeList
+/// representation which is used by the ESTree API in several places.
+class NodeVector {
+ public:
+  using Storage = llvh::SmallVector<ESTree::Node *, 8>;
+
+  NodeVector() = default;
+  NodeVector(std::initializer_list<ESTree::Node *> nodes) {
+    for (auto &node : nodes) {
+      _storage.push_back(node);
+    }
+  }
+
+  NodeVector(ESTree::NodeList &list) {
+    for (auto &node : list) {
+      _storage.push_back(&node);
+    }
+  }
+
+  ~NodeVector() = default;
+
+  size_t size() const {
+    return _storage.size();
+  }
+
+  Storage::const_iterator begin() const {
+    return _storage.begin();
+  }
+
+  Storage::const_iterator end() const {
+    return _storage.end();
+  }
+
+  void append(ESTree::Node *node) {
+    _storage.emplace_back(node);
+  }
+
+  void prepend(ESTree::Node *node) {
+    _storage.insert(_storage.begin(), node);
+  }
+
+  ESTree::NodeList toNodeList() const {
+    ESTree::NodeList nodeList;
+    for (auto &node : _storage) {
+      nodeList.push_back(*node);
+    }
+    return nodeList;
+  }
+
+ private:
+  Storage _storage;
+};
+
+class TransformationsBase
+    : public ESTree::RecursionDepthTracker<TransformationsBase> {
+ public:
+  static constexpr bool kEnableNodeListMutation = true;
+
+  TransformationsBase(Context &context)
+      : context_(context),
+        identLet_(context.getIdentifier("let").getUnderlyingPointer()) {}
+
+  void recursionDepthExceeded(ESTree::Node *n) {
+    context_.getSourceErrorManager().error(
+        n->getEndLoc(), "Too many nested expressions/statements/declarations");
+  }
+
+ protected:
+  Context &context_;
+  UniqueString *const identLet_;
+
+  void doCopyLocation(ESTree::Node *src, ESTree::Node *dest) {
+    if (src != nullptr) {
+      dest->setStartLoc(src->getStartLoc());
+      dest->setEndLoc(src->getEndLoc());
+      dest->setDebugLoc(src->getDebugLoc());
+    }
+  }
+
+  template <typename T>
+  T *copyLocation(ESTree::Node *src, T *dest) {
+    doCopyLocation(src, dest);
+    return dest;
+  }
+
+  template <typename T, typename... Args>
+  T *createTransformedNode(ESTree::Node *src, Args &&...args) {
+    auto *node = new (context_) T(std::forward<Args>(args)...);
+    return copyLocation(src, node);
+  }
+
+  ESTree::IdentifierNode *makeIdentifierNode(
+      ESTree::Node *srcNode,
+      UniqueString *name) {
+    return createTransformedNode<ESTree::IdentifierNode>(
+        srcNode, name, nullptr, false);
+  }
+
+  ESTree::IdentifierNode *makeIdentifierNode(
+      ESTree::Node *srcNode,
+      llvh::StringRef name) {
+    return makeIdentifierNode(
+        srcNode, context_.getIdentifier(name).getUnderlyingPointer());
+  }
+
+  ESTree::Node *makeSingleLetDecl(
+      ESTree::Node *srcNode,
+      ESTree::Node *identifier,
+      ESTree::Node *value) {
+    auto *variableDeclarator =
+        createTransformedNode<ESTree::VariableDeclaratorNode>(
+            srcNode, value, identifier);
+    ESTree::NodeList variableList;
+    variableList.push_back(*variableDeclarator);
+    return createTransformedNode<ESTree::VariableDeclarationNode>(
+        srcNode, identLet_, std::move(variableList));
+  }
+
+  ESTree::Node *makeHermesInternalCall(
+      ESTree::Node *srcNode,
+      llvh::StringRef methodName,
+      const NodeVector &parameters) {
+    auto hermesInternalIdentifier = getHermesInternalIdentifier(srcNode);
+    auto methodIdentifier = makeIdentifierNode(srcNode, methodName);
+
+    auto *getPropertyNode = createTransformedNode<ESTree::MemberExpressionNode>(
+        srcNode, hermesInternalIdentifier, methodIdentifier, false);
+    return createTransformedNode<ESTree::CallExpressionNode>(
+        srcNode, getPropertyNode, nullptr, parameters.toNodeList());
+  }
+
+  virtual ESTree::Node *getHermesInternalIdentifier(ESTree::Node *srcNode) {
+    return nullptr;
+  };
+};
+} // namespace

--- a/lib/AST/AsyncGenerator.cpp
+++ b/lib/AST/AsyncGenerator.cpp
@@ -1,0 +1,185 @@
+#include "hermes/AST/AsyncGenerator.h"
+#include "hermes/AST/TransformationsBase.h"
+
+namespace hermes {
+
+/**
+ * Transforms JS async generators to generators according to babel
+ * transformation
+ * https://babeljs.io/docs/babel-plugin-transform-async-generator-functions
+ *
+ * An async generator:
+ *
+ * async function* userFunction(arguments) {
+ *   // body containing await calls
+ * }
+ *
+ * is transformed into:
+ *
+ * let userFunction = (() => {
+ *      let _ref = _wrapAsyncGenerator(function* (arguments) { // body
+ * containing await calls }); return function userFunction() { return
+ * _ref.apply(this, arguments);
+ *      };
+ * })();
+ *
+ * and an await call inside the async generator body:
+ *  await 1;
+ *
+ * is transformed into:
+ *  yield _awaitAsyncGenerator(1);
+ *
+ * where _awaitAsyncGenerator and _wrapAsyncGenerator are helper functions
+ * defined in 04-AsyncIterator.js
+ *
+ */
+class AsyncGenerator : public TransformationsBase {
+ public:
+  AsyncGenerator(Context &context) : TransformationsBase(context) {}
+
+  void visit(ESTree::FunctionDeclarationNode *funcDecl, ESTree::Node **ppNode) {
+    if (funcDecl->_async && funcDecl->_generator) {
+      recurseFunctionBody(funcDecl->_body, true);
+      auto iife = transformAsyncGeneratorFunction(
+          funcDecl, funcDecl->_params, funcDecl->_body);
+      *ppNode = makeSingleLetDecl(funcDecl, funcDecl->_id, iife);
+    } else {
+      recurseFunctionBody(funcDecl->_body, false);
+    }
+  }
+
+  void visit(ESTree::FunctionExpressionNode *funcExpr, ESTree::Node **ppNode) {
+    if (funcExpr->_async && funcExpr->_generator) {
+      recurseFunctionBody(funcExpr->_body, true);
+      *ppNode = transformAsyncGeneratorFunction(
+          funcExpr, funcExpr->_params, funcExpr->_body);
+    } else {
+      recurseFunctionBody(funcExpr->_body, false);
+    }
+  }
+
+  void visit(ESTree::AwaitExpressionNode *awaitExpr, ESTree::Node **ppNode) {
+    if (!insideAsyncGenerator) {
+      return;
+    }
+
+    auto *awaitCall = makeHermesInternalCall(
+        awaitExpr, "_awaitAsyncGenerator", NodeVector{awaitExpr->_argument});
+    *ppNode = createTransformedNode<ESTree::YieldExpressionNode>(
+        awaitExpr, awaitCall, false);
+  }
+
+  void visit(ESTree::YieldExpressionNode *yieldExpr, ESTree::Node **ppNode) {
+    if (!insideAsyncGenerator) {
+      return;
+    }
+
+    auto awaitExpr =
+        llvh::dyn_cast<ESTree::AwaitExpressionNode>(yieldExpr->_argument);
+    if (awaitExpr) {
+      visit(awaitExpr->_argument);
+      *ppNode = createTransformedNode<ESTree::YieldExpressionNode>(
+          yieldExpr, awaitExpr->_argument, false);
+    }
+  }
+
+  void visit(ESTree::Node *node) {
+    visitESTreeChildren(*this, node);
+  }
+
+ private:
+  void recurseFunctionBody(ESTree::Node *body, bool insideAsyncGenerator) {
+    // recursively transforms all nested async generators and async expressions
+    bool oldInsideAsyncGenerator = this->insideAsyncGenerator;
+    this->insideAsyncGenerator = insideAsyncGenerator;
+    visitESTreeChildren(*this, body);
+    this->insideAsyncGenerator = oldInsideAsyncGenerator;
+  }
+
+  ESTree::Node *transformAsyncGeneratorFunction(
+      ESTree::Node *funcNode,
+      ESTree::NodeList &params,
+      ESTree::Node *body) {
+    auto *refFunc = createTransformedNode<ESTree::FunctionExpressionNode>(
+        funcNode,
+        nullptr, // id is null for anonymous function
+        std::move(params), // params
+        body,
+        nullptr, // typeParameters
+        nullptr, // returnType
+        nullptr, // predicate
+        true, // generator
+        false); // async
+
+    auto *wrappedRef = makeHermesInternalCall(
+        funcNode, "_wrapAsyncGenerator", NodeVector{refFunc});
+
+    // Create the inner function that calls apply on the wrapped reference
+    auto innerFuncBody = createTransformedNode<ESTree::BlockStatementNode>(
+        funcNode,
+        NodeVector{
+            createTransformedNode<ESTree::ReturnStatementNode>(
+                funcNode,
+                createTransformedNode<ESTree::CallExpressionNode>(
+                    funcNode,
+                    createTransformedNode<ESTree::MemberExpressionNode>(
+                        funcNode,
+                        wrappedRef,
+                        makeIdentifierNode(funcNode, "apply"),
+                        false),
+                    nullptr,
+                    NodeVector{
+                        createTransformedNode<ESTree::ThisExpressionNode>(
+                            funcNode),
+                        makeIdentifierNode(funcNode, "arguments")}
+                        .toNodeList()))}
+            .toNodeList());
+
+    auto *innerFunc = createTransformedNode<ESTree::FunctionExpressionNode>(
+        funcNode,
+        nullptr,
+        ESTree::NodeList{},
+        innerFuncBody,
+        nullptr,
+        nullptr,
+        nullptr,
+        false,
+        false);
+
+    // Create the outer IIFE
+    auto *iife = createTransformedNode<ESTree::CallExpressionNode>(
+        funcNode,
+        createTransformedNode<ESTree::FunctionExpressionNode>(
+            funcNode,
+            nullptr,
+            ESTree::NodeList{}, // no params
+            createTransformedNode<ESTree::BlockStatementNode>(
+                funcNode,
+                NodeVector{createTransformedNode<ESTree::ReturnStatementNode>(
+                               funcNode, innerFunc)}
+                    .toNodeList()),
+            nullptr,
+            nullptr,
+            nullptr,
+            false,
+            false),
+        nullptr, // typeArguments
+        ESTree::NodeList{}); // no arguments
+
+    return iife;
+  }
+
+  ESTree::Node *getHermesInternalIdentifier(ESTree::Node *srcNode) override {
+    return makeIdentifierNode(srcNode, "HermesAsyncIteratorsInternal");
+    ;
+  };
+
+  bool insideAsyncGenerator = false;
+};
+
+void transformAsyncGenerators(Context &context, ESTree::Node *node) {
+  AsyncGenerator transformer(context);
+  visitESTreeNodeNoReplace(transformer, node);
+}
+
+} // namespace hermes

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -7,6 +7,7 @@ add_hermes_library(hermesAST
     ASTBuilder.cpp
     ASTUtils.cpp
     ES6Class.cpp
+    AsyncGenerator.cpp
     ESTree.cpp
     ESTreeJSONDumper.cpp
     CommonJS.cpp

--- a/lib/IRGen/ESTreeIRGen.cpp
+++ b/lib/IRGen/ESTreeIRGen.cpp
@@ -459,12 +459,40 @@ Value *ESTreeIRGen::emitIteratorSymbol() {
       "iterator");
 }
 
+Value *ESTreeIRGen::emitAsyncIteratorSymbol() {
+  return Builder.createLoadPropertyInst(
+      Builder.createGetBuiltinClosureInst(BuiltinMethod::globalThis_Symbol),
+      "asyncIterator");
+}
+
 ESTreeIRGen::IteratorRecordSlow ESTreeIRGen::emitGetIteratorSlow(Value *obj) {
   auto *method = Builder.createLoadPropertyInst(obj, emitIteratorSymbol());
   auto *iterator = Builder.createCallInst(
       method, /* newTarget */ Builder.getLiteralUndefined(), obj, {});
 
   emitEnsureObject(iterator, "iterator is not an object");
+  auto *nextMethod = Builder.createLoadPropertyInst(iterator, "next");
+
+  return {iterator, nextMethod};
+}
+
+ESTreeIRGen::IteratorRecordSlow ESTreeIRGen::emitGetAsyncIteratorSlow(
+    Value *obj) {
+  auto *asyncIteratorMethod =
+      Builder.createLoadPropertyInst(obj, emitAsyncIteratorSymbol());
+  auto *syncIteratorMethod =
+      Builder.createLoadPropertyInst(obj, emitIteratorSymbol());
+
+  auto *wrapper = Builder.createLoadPropertyInst(
+      Builder.getGlobalObject(), "HermesAsyncIteratorsInternal");
+  wrapper = Builder.createLoadPropertyInst(
+      wrapper, "_makeAsyncIterator");
+
+  auto *iterator = Builder.createCallInst(
+      wrapper,
+      /* newTarget */ Builder.getLiteralUndefined(),
+      /* this */ Builder.getLiteralUndefined(),
+      {obj, asyncIteratorMethod, syncIteratorMethod});
   auto *nextMethod = Builder.createLoadPropertyInst(iterator, "next");
 
   return {iterator, nextMethod};

--- a/lib/IRGen/ESTreeIRGen.h
+++ b/lib/IRGen/ESTreeIRGen.h
@@ -556,6 +556,7 @@ class ESTreeIRGen {
   void genForOfFastArrayStatement(
       ESTree::ForOfStatementNode *forOfStmt,
       flow::ArrayType *type);
+  void genAsyncForOfStatement(ESTree::ForOfStatementNode *forOfStmt);
   void genWhileLoop(ESTree::WhileStatementNode *loop);
   void genDoWhileLoop(ESTree::DoWhileStatementNode *loop);
 
@@ -1197,6 +1198,9 @@ class ESTreeIRGen {
   /// \return the internal value @@iterator
   Value *emitIteratorSymbol();
 
+  /// \return the internal value @@asyncIterator
+  Value *emitAsyncIteratorSymbol();
+
   /// IteratorRecord as defined in ES2018 7.4.1 GetIterator
   struct IteratorRecordSlow {
     Value *iterator;
@@ -1214,6 +1218,7 @@ class ESTreeIRGen {
   ///
   /// \return (iterator, nextMethod)
   IteratorRecordSlow emitGetIteratorSlow(Value *obj);
+  IteratorRecordSlow emitGetAsyncIteratorSlow(Value *obj);
 
   /// ES2018 7.4.2 IteratorNext
   /// https://www.ecma-international.org/ecma-262/9.0/index.html#sec-iteratornext

--- a/lib/InternalJavaScript/04-AsyncIterator.js
+++ b/lib/InternalJavaScript/04-AsyncIterator.js
@@ -1,0 +1,39 @@
+(function() {
+    function _makeAsyncIterator(iterable, asyncIterMethod, syncIterMethod) {
+        if (asyncIterMethod) {
+            return asyncIterMethod.call(iterable);
+        }
+
+        let syncIterator = syncIterMethod.call(iterable);
+        async function handleResult(result) {
+            if (result.done) {
+                return result;
+            }
+            const value = result.value;
+            // If the value is a promise, wait for it to resolve.
+            const resolvedValue = value instanceof Promise ? await value : value;
+            return { done: false, value: resolvedValue };
+        }
+
+        return {
+            async next() {
+                const result = syncIterator.next();
+                return handleResult(result);
+            },
+            async return(value) {
+                const result = typeof syncIterator.return === 'function' ? syncIterator.return(value) : { done: true, value };
+                return handleResult(result);
+            },
+            async throw(error) {
+                const result = typeof syncIterator.throw === 'function' ? syncIterator.throw(error) : { done: true, value: error };
+                return handleResult(result);
+            }
+        };
+    }
+
+    var HermesAsyncIteratorsInternal = {
+        _makeAsyncIterator
+    };
+    Object.freeze(HermesAsyncIteratorsInternal);
+    globalThis.HermesAsyncIteratorsInternal = HermesAsyncIteratorsInternal;
+})();

--- a/lib/InternalJavaScript/04-AsyncIterator.js
+++ b/lib/InternalJavaScript/04-AsyncIterator.js
@@ -1,4 +1,88 @@
+// References:
+// https://github.com/babel/babel/blob/dcfa42b933299644c4e78168cb4678ecbfae67ed/packages/babel-runtime-corejs3/helpers/esm/OverloadYield.js
+// https://github.com/babel/babel/blob/dcfa42b933299644c4e78168cb4678ecbfae67ed/packages/babel-runtime-corejs3/helpers/esm/wrapAsyncGenerator.js
+// https://github.com/babel/babel/blob/dcfa42b933299644c4e78168cb4678ecbfae67ed/packages/babel-runtime-corejs3/helpers/esm/awaitAsyncGenerator.js
+// https://babel.dev/repl#?browsers=chrome%2062&build=&builtIns=false&corejs=false&spec=false&loose=false&code_lz=IYZwngdgxgBAZgV2gFwJYHsICp7vQCgEoYBvAKBhmAHdhVkYAFAJ3QFtUQBTAOma5DoANgDcu-AOTAJhANwBICjDCouQgCYwAjAAZZSlWs006DFu069-g0eIkAjGfsqGNVWvSasO3PgOFiklBOBqpuACxkAL5kQA&debug=false&forceAllTransforms=true&modules=false&shippedProposals=true&evaluate=false&fileSize=true&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=true&targets=&version=7.13.15&externalPlugins=&assumptions=%7B%7D
+
 (function() {
+    function _OverloadYield(e, d) {
+        this.v = e, this.k = d;
+    }
+
+    function _AsyncGenerator(e) {
+        var r, t;
+        function resume(r, t) {
+            try {
+                var n = e[r](t),
+                    o = n.value,
+                    u = o instanceof _OverloadYield;
+                Promise.resolve(u ? o.v : o).then(function (t) {
+                    if (u) {
+                        var i = "return" === r ? "return" : "next";
+                        if (!o.k || t.done) return resume(i, t);
+                        t = e[i](t).value;
+                    }
+                    settle(n.done ? "return" : "normal", t);
+                }, function (e) {
+                    resume("throw", e);
+                });
+            } catch (e) {
+                settle("throw", e);
+            }
+        }
+        function settle(e, n) {
+            switch (e) {
+                case "return":
+                    r.resolve({
+                        value: n,
+                        done: !0
+                    });
+                    break;
+                case "throw":
+                    r.reject(n);
+                    break;
+                default:
+                    r.resolve({
+                        value: n,
+                        done: !1
+                    });
+            }
+            (r = r.next) ? resume(r.key, r.arg) : t = null;
+        }
+        this._invoke = function (e, n) {
+            return new Promise(function (o, u) {
+                var i = {
+                    key: e,
+                    arg: n,
+                    resolve: o,
+                    reject: u,
+                    next: null
+                };
+                t ? t = t.next = i : (r = t = i, resume(e, n));
+            });
+        }, "function" != typeof e["return"] && (this["return"] = void 0);
+    }
+
+    _AsyncGenerator.prototype[Symbol.asyncIterator] = function () {
+        return this;
+    }, _AsyncGenerator.prototype.next = function (e) {
+        return this._invoke("next", e);
+    }, _AsyncGenerator.prototype["throw"] = function (e) {
+        return this._invoke("throw", e);
+    }, _AsyncGenerator.prototype["return"] = function (e) {
+        return this._invoke("return", e);
+    };
+
+    function _wrapAsyncGenerator(e) {
+        return function () {
+            return new _AsyncGenerator(e.apply(this, arguments));
+        };
+    }
+
+    function _awaitAsyncGenerator(e) {
+        return new _OverloadYield(e, 0);
+    }
+
     function _makeAsyncIterator(iterable, asyncIterMethod, syncIterMethod) {
         if (asyncIterMethod) {
             return asyncIterMethod.call(iterable);
@@ -32,7 +116,9 @@
     }
 
     var HermesAsyncIteratorsInternal = {
-        _makeAsyncIterator
+        _makeAsyncIterator,
+        _wrapAsyncGenerator,
+        _awaitAsyncGenerator,
     };
     Object.freeze(HermesAsyncIteratorsInternal);
     globalThis.HermesAsyncIteratorsInternal = HermesAsyncIteratorsInternal;

--- a/lib/Sema/SemResolve.cpp
+++ b/lib/Sema/SemResolve.cpp
@@ -13,6 +13,7 @@
 #include "SemanticResolver.h"
 #include "hermes/AST/ES6Class.h"
 #include "hermes/AST/ESTree.h"
+#include "hermes/AST/AsyncGenerator.h"
 #include "hermes/Support/PerfSection.h"
 
 namespace hermes {
@@ -162,6 +163,8 @@ bool resolveAST(
     const DeclarationFileListTy &ambientDecls) {
   if (astContext.getConvertES6Classes())
     transformES6Classes(astContext, root);
+
+  transformAsyncGenerators(astContext, root);
 
   PerfSection validation("Resolving JavaScript global AST");
   // Resolve the entire AST.

--- a/lib/Sema/SemanticResolver.cpp
+++ b/lib/Sema/SemanticResolver.cpp
@@ -459,8 +459,6 @@ void SemanticResolver::visit(ESTree::ForInStatementNode *node) {
 }
 
 void SemanticResolver::visit(ESTree::ForOfStatementNode *node) {
-  if (compile_ && node->_await)
-    sm_.error(node->getStartLoc(), "for await is not supported");
   visitForInOf(node, node, node->_left, node->_right, node->_body);
 }
 


### PR DESCRIPTION
This PR introduces support for async iterators via IR and AST transformations.

**Key changes related to async generators**
- Added an `AsyncGenerator` class that converts any async generator to a generator. This follows the same logic implemented by [Babel](https://babeljs.io/docs/babel-plugin-transform-async-generator-functions).
- Moved part of Class transformation logic to a common TransormationsBase class.

**Key changes related to for await of loops**
- The helper function `_makeAsyncIterator` is used to create an async iterator for a given iterable. It checks if an async iterator method is available; if not, it creates an async iterator from a synchronous iterator by wrapping its results in promises.
- Added a `genAsyncForOfStatement` which handles the for await of loop by iterating over the async iterator object. It follows the same rules described [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)

**Test262 results on async iterators tests:** 98.46%.